### PR TITLE
Capture retryable response details for 429 errors

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -333,6 +333,8 @@ pub(crate) async fn stream_chat_completions(
                     return Err(CodexErr::RetryLimit(RetryLimitReachedError {
                         status,
                         request_id: None,
+                        body: None,
+                        headers: None,
                     }));
                 }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -22,6 +22,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::io::ReaderStream;
 use tracing::debug;
+use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
@@ -388,8 +389,18 @@ impl ModelClient {
                 }
 
                 if status == StatusCode::TOO_MANY_REQUESTS {
-                    let rate_limit_snapshot = parse_rate_limit_snapshot(res.headers());
-                    let body = res.json::<ErrorResponse>().await.ok();
+                    let headers = res.headers().clone();
+                    let body_text = res.text().await.unwrap_or_default();
+
+                    info!(
+                        status = %status,
+                        headers = ?headers,
+                        body = %body_text,
+                        "Responses API returned 429 Too Many Requests"
+                    );
+
+                    let rate_limit_snapshot = parse_rate_limit_snapshot(&headers);
+                    let body = serde_json::from_str::<ErrorResponse>(&body_text).ok();
                     if let Some(ErrorResponse { error }) = body {
                         if error.r#type.as_deref() == Some("usage_limit_reached") {
                             // Prefer the plan_type provided in the error message if present
@@ -409,12 +420,22 @@ impl ModelClient {
                             return Err(StreamAttemptError::Fatal(CodexErr::UsageNotIncluded));
                         }
                     }
+
+                    return Err(StreamAttemptError::RetryableHttpError {
+                        status,
+                        retry_after,
+                        request_id,
+                        body: Some(body_text),
+                        headers: Some(headers),
+                    });
                 }
 
                 Err(StreamAttemptError::RetryableHttpError {
                     status,
                     retry_after,
                     request_id,
+                    body: None,
+                    headers: None,
                 })
             }
             Err(e) => Err(StreamAttemptError::RetryableTransportError(e.into())),
@@ -459,6 +480,8 @@ enum StreamAttemptError {
         status: StatusCode,
         retry_after: Option<Duration>,
         request_id: Option<String>,
+        body: Option<String>,
+        headers: Option<HeaderMap>,
     },
     RetryableTransportError(CodexErr),
     Fatal(CodexErr),
@@ -484,12 +507,21 @@ impl StreamAttemptError {
     fn into_error(self) -> CodexErr {
         match self {
             Self::RetryableHttpError {
-                status, request_id, ..
+                status,
+                request_id,
+                body,
+                headers,
+                ..
             } => {
                 if status == StatusCode::INTERNAL_SERVER_ERROR {
                     CodexErr::InternalServerError
                 } else {
-                    CodexErr::RetryLimit(RetryLimitReachedError { status, request_id })
+                    CodexErr::RetryLimit(RetryLimitReachedError {
+                        status,
+                        request_id,
+                        body,
+                        headers,
+                    })
                 }
             }
             Self::RetryableTransportError(error) => error,

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -4,6 +4,7 @@ use crate::token_data::PlanType;
 use codex_protocol::ConversationId;
 use codex_protocol::protocol::RateLimitSnapshot;
 use reqwest::StatusCode;
+use reqwest::header::HeaderMap;
 use serde_json;
 use std::io;
 use std::time::Duration;
@@ -162,19 +163,27 @@ impl std::error::Error for UnexpectedResponseError {}
 pub struct RetryLimitReachedError {
     pub status: StatusCode,
     pub request_id: Option<String>,
+    pub body: Option<String>,
+    pub headers: Option<HeaderMap>,
 }
 
 impl std::fmt::Display for RetryLimitReachedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "exceeded retry limit, last status: {}{}",
-            self.status,
-            self.request_id
-                .as_ref()
-                .map(|id| format!(", request id: {id}"))
-                .unwrap_or_default()
-        )
+        write!(f, "exceeded retry limit, last status: {}", self.status)?;
+
+        if let Some(request_id) = &self.request_id {
+            write!(f, ", request id: {request_id}")?;
+        }
+
+        if let Some(body) = &self.body {
+            write!(f, ", body: {body}")?;
+        }
+
+        if let Some(headers) = &self.headers {
+            write!(f, ", headers: {:?}", headers)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -311,6 +320,8 @@ pub fn get_error_message_ui(e: &CodexErr) -> String {
 mod tests {
     use super::*;
     use codex_protocol::protocol::RateLimitWindow;
+    use reqwest::header::HeaderMap;
+    use reqwest::header::HeaderValue;
 
     fn rate_limit_snapshot() -> RateLimitSnapshot {
         RateLimitSnapshot {
@@ -455,5 +466,25 @@ mod tests {
             err.to_string(),
             "You've hit your usage limit. Try again in less than a minute."
         );
+    }
+
+    #[test]
+    fn retry_limit_error_includes_details() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test", HeaderValue::from_static("value"));
+
+        let err = RetryLimitReachedError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            request_id: Some("abc123".to_string()),
+            body: Some("{\"error\":\"rate limited\"}".to_string()),
+            headers: Some(headers.clone()),
+        };
+
+        let formatted = err.to_string();
+        assert!(formatted.contains("request id: abc123"));
+        assert!(formatted.contains("body: {\"error\":\"rate limited\"}"));
+        assert!(formatted.contains("headers:"));
+        assert!(formatted.contains("\"x-test\""));
+        assert!(formatted.contains("\"value\""));
     }
 }


### PR DESCRIPTION
## Summary
- log the raw headers/body for 429 responses in the streaming responses client before retrying
- carry the captured headers/body through StreamAttemptError into RetryLimitReachedError formatting
- extend RetryLimitReachedError display output and add a regression test covering the new details

## Testing
- just fmt
- cargo test -p codex-core *(fails: suite::client::azure_overrides_assign_properties_used_for_responses_url, suite::client::env_var_overrides_loaded_auth due to missing Azure env configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a218fa0832988a5928382bb1fe5