### PR TITLE
Handle tool call chunks arriving after finish reason

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -358,6 +358,19 @@ pub(crate) async fn stream_chat_completions(
     }
 }
 
+/// State to accumulate a function call across streaming chunks.
+/// OpenAI-compatible providers may split the `arguments` string over multiple
+/// `delta` events until the chunk whose `finish_reason` is `tool_calls` is
+/// emitted. We keep collecting the pieces here and forward a single
+/// `ResponseItem::FunctionCall` once the call is complete.
+#[derive(Default)]
+struct FunctionCallState {
+    name: Option<String>,
+    arguments: String,
+    call_id: Option<String>,
+    active: bool,
+}
+
 /// Lightweight SSE processor for the Chat Completions streaming format. The
 /// output is mapped onto Codex's internal [`ResponseEvent`] so that the rest
 /// of the pipeline can stay agnostic of the underlying wire format.
@@ -371,20 +384,8 @@ async fn process_chat_sse<S>(
 {
     let mut stream = stream.eventsource();
 
-    // State to accumulate a function call across streaming chunks.
-    // OpenAI may split the `arguments` string over multiple `delta` events
-    // until the chunk whose `finish_reason` is `tool_calls` is emitted. We
-    // keep collecting the pieces here and forward a single
-    // `ResponseItem::FunctionCall` once the call is complete.
-    #[derive(Default)]
-    struct FunctionCallState {
-        name: Option<String>,
-        arguments: String,
-        call_id: Option<String>,
-        active: bool,
-    }
-
     let mut fn_call_state = FunctionCallState::default();
+    let mut pending_finish_reason: Option<String> = None;
     let mut assistant_text = String::new();
     let mut reasoning_text = String::new();
 
@@ -401,7 +402,15 @@ async fn process_chat_sse<S>(
                 return;
             }
             Ok(None) => {
-                // Stream closed gracefully – emit Completed with dummy id.
+                emit_finish_events(
+                    &tx_event,
+                    pending_finish_reason.as_deref(),
+                    &fn_call_state,
+                    &mut assistant_text,
+                    &mut reasoning_text,
+                )
+                .await;
+
                 let _ = tx_event
                     .send(Ok(ResponseEvent::Completed {
                         response_id: String::new(),
@@ -423,30 +432,14 @@ async fn process_chat_sse<S>(
 
         // OpenAI Chat streaming sends a literal string "[DONE]" when finished.
         if sse.data.trim() == "[DONE]" {
-            // Emit any finalized items before closing so downstream consumers receive
-            // terminal events for both assistant content and raw reasoning.
-            if !assistant_text.is_empty() {
-                let item = ResponseItem::Message {
-                    role: "assistant".to_string(),
-                    content: vec![ContentItem::OutputText {
-                        text: std::mem::take(&mut assistant_text),
-                    }],
-                    id: None,
-                };
-                let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-            }
-
-            if !reasoning_text.is_empty() {
-                let item = ResponseItem::Reasoning {
-                    id: String::new(),
-                    summary: Vec::new(),
-                    content: Some(vec![ReasoningItemContent::ReasoningText {
-                        text: std::mem::take(&mut reasoning_text),
-                    }]),
-                    encrypted_content: None,
-                };
-                let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-            }
+            emit_finish_events(
+                &tx_event,
+                pending_finish_reason.as_deref(),
+                &fn_call_state,
+                &mut assistant_text,
+                &mut reasoning_text,
+            )
+            .await;
 
             let _ = tx_event
                 .send(Ok(ResponseEvent::Completed {
@@ -586,75 +579,60 @@ async fn process_chat_sse<S>(
 
             // Emit end-of-turn when finish_reason signals completion.
             if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
-                match finish_reason {
-                    "tool_calls" | "function_call" if fn_call_state.active => {
-                        // First, flush the terminal raw reasoning so UIs can finalize
-                        // the reasoning stream before any exec/tool events begin.
-                        if !reasoning_text.is_empty() {
-                            let item = ResponseItem::Reasoning {
-                                id: String::new(),
-                                summary: Vec::new(),
-                                content: Some(vec![ReasoningItemContent::ReasoningText {
-                                    text: std::mem::take(&mut reasoning_text),
-                                }]),
-                                encrypted_content: None,
-                            };
-                            let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-                        }
-
-                        // Then emit the FunctionCall response item.
-                        let item = ResponseItem::FunctionCall {
-                            id: None,
-                            name: fn_call_state.name.clone().unwrap_or_else(|| "".to_string()),
-                            arguments: fn_call_state.arguments.clone(),
-                            call_id: fn_call_state.call_id.clone().unwrap_or_else(String::new),
-                        };
-
-                        let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-                    }
-                    "stop" => {
-                        // Regular turn without tool-call. Emit the final assistant message
-                        // as a single OutputItemDone so non-delta consumers see the result.
-                        if !assistant_text.is_empty() {
-                            let item = ResponseItem::Message {
-                                role: "assistant".to_string(),
-                                content: vec![ContentItem::OutputText {
-                                    text: std::mem::take(&mut assistant_text),
-                                }],
-                                id: None,
-                            };
-                            let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-                        }
-                        // Also emit a terminal Reasoning item so UIs can finalize raw reasoning.
-                        if !reasoning_text.is_empty() {
-                            let item = ResponseItem::Reasoning {
-                                id: String::new(),
-                                summary: Vec::new(),
-                                content: Some(vec![ReasoningItemContent::ReasoningText {
-                                    text: std::mem::take(&mut reasoning_text),
-                                }]),
-                                encrypted_content: None,
-                            };
-                            let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-                        }
-                    }
-                    _ => {}
-                }
-
-                // Emit Completed regardless of reason so the agent can advance.
-                let _ = tx_event
-                    .send(Ok(ResponseEvent::Completed {
-                        response_id: String::new(),
-                        token_usage: None,
-                    }))
-                    .await;
-
-                // Prepare for potential next turn (should not happen in same stream).
-                // fn_call_state = FunctionCallState::default();
-
-                return; // End processing for this SSE stream.
+                pending_finish_reason = Some(finish_reason.to_string());
             }
         }
+    }
+}
+
+async fn emit_finish_events(
+    tx_event: &mpsc::Sender<Result<ResponseEvent>>,
+    finish_reason: Option<&str>,
+    fn_call_state: &FunctionCallState,
+    assistant_text: &mut String,
+    reasoning_text: &mut String,
+) {
+    if matches!(finish_reason, Some("tool_calls" | "function_call")) && fn_call_state.active {
+        if !reasoning_text.is_empty() {
+            let text = std::mem::take(reasoning_text);
+            let item = ResponseItem::Reasoning {
+                id: String::new(),
+                summary: Vec::new(),
+                content: Some(vec![ReasoningItemContent::ReasoningText { text }]),
+                encrypted_content: None,
+            };
+            let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
+        }
+
+        let item = ResponseItem::FunctionCall {
+            id: None,
+            name: fn_call_state.name.clone().unwrap_or_default(),
+            arguments: fn_call_state.arguments.clone(),
+            call_id: fn_call_state.call_id.clone().unwrap_or_default(),
+        };
+        let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
+        return;
+    }
+
+    if !assistant_text.is_empty() {
+        let text = std::mem::take(assistant_text);
+        let item = ResponseItem::Message {
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText { text }],
+            id: None,
+        };
+        let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
+    }
+
+    if !reasoning_text.is_empty() {
+        let text = std::mem::take(reasoning_text);
+        let item = ResponseItem::Reasoning {
+            id: String::new(),
+            summary: Vec::new(),
+            content: Some(vec![ReasoningItemContent::ReasoningText { text }]),
+            encrypted_content: None,
+        };
+        let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
     }
 }
 

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -14,6 +14,7 @@ use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use core_test_support::load_default_config_for_test;
 use futures::StreamExt;
+use serde_json::json;
 use tempfile::TempDir;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -368,6 +369,65 @@ async fn streams_legacy_function_call_delta() {
             assert_eq!(name, "run");
             assert_eq!(arguments, "{\"foo\":1}");
             assert!(call_id.is_empty());
+        }
+        other => panic!("expected function call, got {other:?}"),
+    }
+
+    assert!(matches!(events[1], ResponseEvent::Completed { .. }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tool_call_arguments_may_continue_after_finish_reason() {
+    if network_disabled() {
+        println!(
+            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
+        );
+        return;
+    }
+
+    let chunk1 = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "run",
+                        "arguments": "{\"command\":[\"mkdir\",\"-p\""
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+
+    let chunk2 = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "function": {
+                        "arguments": ",\"diagrams\"]}"
+                    }
+                }]
+            }
+        }]
+    });
+
+    let sse = format!("data: {chunk1}\n\ndata: {chunk2}\n\ndata: [DONE]\n\n");
+
+    let events = run_stream(&sse).await;
+    assert_eq!(events.len(), 2, "unexpected events: {events:?}");
+
+    match &events[0] {
+        ResponseEvent::OutputItemDone(ResponseItem::FunctionCall {
+            name,
+            arguments,
+            call_id,
+            ..
+        }) => {
+            assert_eq!(name, "run");
+            assert_eq!(call_id, "call_1");
+            assert_eq!(arguments, "{\"command\":[\"mkdir\",\"-p\",\"diagrams\"]}");
         }
         other => panic!("expected function call, got {other:?}"),
     }


### PR DESCRIPTION
## Summary
- defer chat completion finalization until the stream closes so tool-call arguments arriving after `finish_reason` are captured
- consolidate stream finalization into a helper that emits reasoning or function calls once we know the outcome
- add a regression test covering tool-call arguments that continue after the finish chunk

## Testing
- cargo test -p codex-core tool_call_arguments_may_continue_after_finish_reason

------
https://chatgpt.com/codex/tasks/task_e_68e19ecba5008329830cfdfaae08d403