### PR TITLE
Improve update_plan error guidance for malformed payloads

### DIFF
--- a/codex-rs/core/src/tools/handlers/plan.rs
+++ b/codex-rs/core/src/tools/handlers/plan.rs
@@ -113,7 +113,19 @@ pub(crate) async fn handle_update_plan(
 }
 
 fn parse_update_plan_arguments(arguments: &str) -> Result<UpdatePlanArgs, FunctionCallError> {
-    serde_json::from_str::<UpdatePlanArgs>(arguments).map_err(|e| {
-        FunctionCallError::RespondToModel(format!("failed to parse function arguments: {e}"))
+    serde_json::from_str::<UpdatePlanArgs>(arguments).map_err(|error| {
+        use serde_json::error::Category;
+
+        let example =
+            r#"Example: {"plan": [{"step": "Outline solution", "status": "in_progress"}]}"#;
+        let hint = match error.classify() {
+            Category::Data => "Ensure `plan` is an array of objects with `step` and `status` (pending, in_progress, completed).",
+            Category::Syntax | Category::Eof => "Provide the arguments as valid JSON with the `plan` array of steps.",
+            Category::Io => "Encountered an unexpected I/O error while reading the arguments.",
+        };
+
+        FunctionCallError::RespondToModel(format!(
+            "failed to parse function arguments: {error}. {hint} {example}"
+        ))
     })
 }

--- a/codex-rs/core/tests/suite/tool_harness.rs
+++ b/codex-rs/core/tests/suite/tool_harness.rs
@@ -315,6 +315,10 @@ async fn update_plan_tool_rejects_malformed_payload() -> anyhow::Result<()> {
         output_text.contains("failed to parse function arguments"),
         "expected parse error message in output text, got {output_text:?}"
     );
+    assert!(
+        output_text.contains("Ensure `plan` is an array of objects"),
+        "expected guidance about the plan format in output text, got {output_text:?}"
+    );
     if let Some(success_flag) = output_item
         .get("output")
         .and_then(|value| value.as_object())


### PR DESCRIPTION
## Summary
- add contextual hints when parsing update_plan arguments fails and include an example payload
- extend the tool harness test to verify the new guidance is surfaced

## Testing
- cargo test -p codex-core update_plan_tool_rejects_malformed_payload

------
https://chatgpt.com/codex/tasks/task_e_68e2d1b9325c83299476bc2e26c6eed3