### PR TITLE
Fix missing closing braces in MCP tool call arguments

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -37,6 +37,7 @@ mod mcp_tool_call;
 mod message_history;
 mod model_provider_info;
 pub mod parse_command;
+mod tool_arguments;
 mod truncate;
 mod unified_exec;
 mod user_instructions;

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -179,10 +179,24 @@ mod tests {
     }
 
     #[test]
+    fn fix_unclosed_json_delimiters_adds_missing_array_bracket() {
+        let args = "{\"items\": [1, 2";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"items\": [1, 2]}");
+    }
+
+    #[test]
     fn fix_unclosed_json_delimiters_ignores_braces_in_strings() {
         let args = "{\"text\": \"use {curly}\"";
         let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
         assert_eq!(fixed, "{\"text\": \"use {curly}\"}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_preserves_trailing_whitespace() {
+        let args = "{\"foo\": 1\n";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"foo\": 1}\n");
     }
 
     #[test]

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use tracing::error;
+use tracing::warn;
 
 use crate::codex::Session;
 use crate::protocol::Event;
@@ -22,22 +23,20 @@ pub(crate) async fn handle_mcp_tool_call(
     arguments: String,
 ) -> ResponseInputItem {
     // Parse the `arguments` as JSON. An empty string is OK, but invalid JSON
-    // is not.
-    let arguments_value = if arguments.trim().is_empty() {
-        None
-    } else {
-        match serde_json::from_str::<serde_json::Value>(&arguments) {
-            Ok(value) => Some(value),
-            Err(e) => {
-                error!("failed to parse tool call arguments: {e}");
-                return ResponseInputItem::FunctionCallOutput {
-                    call_id: call_id.clone(),
-                    output: FunctionCallOutputPayload {
-                        content: format!("err: {e}"),
-                        success: Some(false),
-                    },
-                };
-            }
+    // is not. If parsing fails because the model omitted a closing delimiter,
+    // attempt to synthesize the missing characters so that we can still run
+    // the tool call.
+    let arguments_value = match parse_tool_arguments(&arguments) {
+        Ok(value) => value,
+        Err(e) => {
+            error!("failed to parse tool call arguments: {e}");
+            return ResponseInputItem::FunctionCallOutput {
+                call_id: call_id.clone(),
+                output: FunctionCallOutputPayload {
+                    content: format!("err: {e}"),
+                    success: Some(false),
+                },
+            };
         }
     };
 
@@ -77,4 +76,118 @@ async fn notify_mcp_tool_call_event(sess: &Session, sub_id: &str, event: EventMs
         msg: event,
     })
     .await;
+}
+
+fn parse_tool_arguments(arguments: &str) -> Result<Option<serde_json::Value>, serde_json::Error> {
+    if arguments.trim().is_empty() {
+        return Ok(None);
+    }
+
+    match serde_json::from_str(arguments) {
+        Ok(value) => Ok(Some(value)),
+        Err(original_error) => {
+            if let Some(fixed) = fix_unclosed_json_delimiters(arguments) {
+                match serde_json::from_str(&fixed) {
+                    Ok(value) => {
+                        warn!("synthesized missing closing delimiters for tool arguments");
+                        Ok(Some(value))
+                    }
+                    Err(_) => Err(original_error),
+                }
+            } else {
+                Err(original_error)
+            }
+        }
+    }
+}
+
+fn fix_unclosed_json_delimiters(arguments: &str) -> Option<String> {
+    let trimmed = arguments.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let trailing_whitespace = &arguments[trimmed.len()..];
+    let mut result = trimmed.to_string();
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in trimmed.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+        } else {
+            match ch {
+                '"' => in_string = true,
+                '{' => stack.push('}'),
+                '[' => stack.push(']'),
+                '(' => stack.push(')'),
+                '}' | ']' | ')' => {
+                    if let Some(expected) = stack.pop() {
+                        if expected != ch {
+                            return None;
+                        }
+                    } else {
+                        return None;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if stack.is_empty() {
+        return None;
+    }
+
+    while let Some(ch) = stack.pop() {
+        result.push(ch);
+    }
+
+    result.push_str(trailing_whitespace);
+
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fix_unclosed_json_delimiters;
+    use super::parse_tool_arguments;
+
+    #[test]
+    fn parse_tool_arguments_handles_missing_closing_brace() {
+        let args = "{\"foo\": \"bar\"";
+        let parsed = parse_tool_arguments(args).expect("should parse");
+        let value = parsed.expect("expected some value");
+        assert_eq!(value["foo"], "bar");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_adds_multiple_missing_braces() {
+        let args = "{\"outer\": {\"inner\": 1";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"outer\": {\"inner\": 1}}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_ignores_braces_in_strings() {
+        let args = "{\"text\": \"use {curly}\"";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"text\": \"use {curly}\"}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_returns_none_when_not_needed() {
+        let args = "{\"foo\": true}";
+        assert!(fix_unclosed_json_delimiters(args).is_none());
+    }
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1,7 +1,6 @@
 use std::time::Instant;
 
 use tracing::error;
-use tracing::warn;
 
 use crate::codex::Session;
 use crate::protocol::Event;
@@ -9,6 +8,7 @@ use crate::protocol::EventMsg;
 use crate::protocol::McpInvocation;
 use crate::protocol::McpToolCallBeginEvent;
 use crate::protocol::McpToolCallEndEvent;
+use crate::tool_arguments::parse_tool_arguments;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
 
@@ -76,132 +76,4 @@ async fn notify_mcp_tool_call_event(sess: &Session, sub_id: &str, event: EventMs
         msg: event,
     })
     .await;
-}
-
-fn parse_tool_arguments(arguments: &str) -> Result<Option<serde_json::Value>, serde_json::Error> {
-    if arguments.trim().is_empty() {
-        return Ok(None);
-    }
-
-    match serde_json::from_str(arguments) {
-        Ok(value) => Ok(Some(value)),
-        Err(original_error) => {
-            if let Some(fixed) = fix_unclosed_json_delimiters(arguments) {
-                match serde_json::from_str(&fixed) {
-                    Ok(value) => {
-                        warn!("synthesized missing closing delimiters for tool arguments");
-                        Ok(Some(value))
-                    }
-                    Err(_) => Err(original_error),
-                }
-            } else {
-                Err(original_error)
-            }
-        }
-    }
-}
-
-fn fix_unclosed_json_delimiters(arguments: &str) -> Option<String> {
-    let trimmed = arguments.trim_end();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let trailing_whitespace = &arguments[trimmed.len()..];
-    let mut result = trimmed.to_string();
-    let mut stack: Vec<char> = Vec::new();
-    let mut in_string = false;
-    let mut escaped = false;
-
-    for ch in trimmed.chars() {
-        if in_string {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => escaped = true,
-                '"' => in_string = false,
-                _ => {}
-            }
-        } else {
-            match ch {
-                '"' => in_string = true,
-                '{' => stack.push('}'),
-                '[' => stack.push(']'),
-                '(' => stack.push(')'),
-                '}' | ']' | ')' => {
-                    if let Some(expected) = stack.pop() {
-                        if expected != ch {
-                            return None;
-                        }
-                    } else {
-                        return None;
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    if stack.is_empty() {
-        return None;
-    }
-
-    while let Some(ch) = stack.pop() {
-        result.push(ch);
-    }
-
-    result.push_str(trailing_whitespace);
-
-    Some(result)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::fix_unclosed_json_delimiters;
-    use super::parse_tool_arguments;
-
-    #[test]
-    fn parse_tool_arguments_handles_missing_closing_brace() {
-        let args = "{\"foo\": \"bar\"";
-        let parsed = parse_tool_arguments(args).expect("should parse");
-        let value = parsed.expect("expected some value");
-        assert_eq!(value["foo"], "bar");
-    }
-
-    #[test]
-    fn fix_unclosed_json_delimiters_adds_multiple_missing_braces() {
-        let args = "{\"outer\": {\"inner\": 1";
-        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
-        assert_eq!(fixed, "{\"outer\": {\"inner\": 1}}");
-    }
-
-    #[test]
-    fn fix_unclosed_json_delimiters_adds_missing_array_bracket() {
-        let args = "{\"items\": [1, 2";
-        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
-        assert_eq!(fixed, "{\"items\": [1, 2]}");
-    }
-
-    #[test]
-    fn fix_unclosed_json_delimiters_ignores_braces_in_strings() {
-        let args = "{\"text\": \"use {curly}\"";
-        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
-        assert_eq!(fixed, "{\"text\": \"use {curly}\"}");
-    }
-
-    #[test]
-    fn fix_unclosed_json_delimiters_preserves_trailing_whitespace() {
-        let args = "{\"foo\": 1\n";
-        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
-        assert_eq!(fixed, "{\"foo\": 1}\n");
-    }
-
-    #[test]
-    fn fix_unclosed_json_delimiters_returns_none_when_not_needed() {
-        let args = "{\"foo\": true}";
-        assert!(fix_unclosed_json_delimiters(args).is_none());
-    }
 }

--- a/codex-rs/core/src/tool_arguments.rs
+++ b/codex-rs/core/src/tool_arguments.rs
@@ -1,0 +1,163 @@
+use tracing::warn;
+
+pub(crate) fn parse_tool_arguments(
+    arguments: &str,
+) -> Result<Option<serde_json::Value>, serde_json::Error> {
+    if arguments.trim().is_empty() {
+        return Ok(None);
+    }
+
+    match serde_json::from_str(arguments) {
+        Ok(value) => Ok(Some(value)),
+        Err(original_error) => {
+            if let Some(fixed) = fix_unclosed_json_delimiters(arguments) {
+                match serde_json::from_str(&fixed) {
+                    Ok(value) => {
+                        warn!("synthesized missing closing delimiters for tool arguments");
+                        Ok(Some(value))
+                    }
+                    Err(_) => Err(original_error),
+                }
+            } else {
+                Err(original_error)
+            }
+        }
+    }
+}
+
+pub(crate) fn repair_tool_arguments(arguments: &str) -> Option<String> {
+    if arguments.trim().is_empty() {
+        return None;
+    }
+
+    if serde_json::from_str::<serde_json::Value>(arguments).is_ok() {
+        return None;
+    }
+
+    let fixed = fix_unclosed_json_delimiters(arguments)?;
+    serde_json::from_str::<serde_json::Value>(&fixed).ok()?;
+    Some(fixed)
+}
+
+fn fix_unclosed_json_delimiters(arguments: &str) -> Option<String> {
+    let trimmed = arguments.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let trailing_whitespace = &arguments[trimmed.len()..];
+    let mut result = trimmed.to_string();
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in trimmed.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+        } else {
+            match ch {
+                '"' => in_string = true,
+                '{' => stack.push('}'),
+                '[' => stack.push(']'),
+                '(' => stack.push(')'),
+                '}' | ']' | ')' => {
+                    if let Some(expected) = stack.pop() {
+                        if expected != ch {
+                            return None;
+                        }
+                    } else {
+                        return None;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if stack.is_empty() {
+        return None;
+    }
+
+    while let Some(ch) = stack.pop() {
+        result.push(ch);
+    }
+
+    result.push_str(trailing_whitespace);
+
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parse_tool_arguments_handles_missing_closing_brace() {
+        let args = "{\"foo\": \"bar\"";
+        let parsed = parse_tool_arguments(args).expect("should parse");
+        let value = parsed.expect("expected some value");
+        assert_eq!(value["foo"], "bar");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_adds_multiple_missing_braces() {
+        let args = "{\"outer\": {\"inner\": 1";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"outer\": {\"inner\": 1}}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_adds_missing_array_bracket() {
+        let args = "{\"items\": [1, 2";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"items\": [1, 2]}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_ignores_braces_in_strings() {
+        let args = "{\"text\": \"use {curly}\"";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"text\": \"use {curly}\"}");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_preserves_trailing_whitespace() {
+        let args = "{\"foo\": 1\n";
+        let fixed = fix_unclosed_json_delimiters(args).expect("should fix");
+        assert_eq!(fixed, "{\"foo\": 1}\n");
+    }
+
+    #[test]
+    fn fix_unclosed_json_delimiters_returns_none_when_not_needed() {
+        let args = "{\"foo\": true}";
+        assert!(fix_unclosed_json_delimiters(args).is_none());
+    }
+
+    #[test]
+    fn repair_tool_arguments_returns_fixed_string_when_needed() {
+        let args = "{\"foo\": 1";
+        let repaired = repair_tool_arguments(args).expect("should repair");
+        assert_eq!(repaired, "{\"foo\": 1}");
+    }
+
+    #[test]
+    fn repair_tool_arguments_returns_none_when_valid() {
+        let args = "{\"foo\": 1}";
+        assert!(repair_tool_arguments(args).is_none());
+    }
+
+    #[test]
+    fn repair_tool_arguments_returns_none_for_empty() {
+        assert!(repair_tool_arguments("").is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- recover from Qwen responses that omit closing delimiters in tool call argument JSON
- add helpers and unit tests to balance delimiters before dispatching MCP tool calls

## Testing
- `cargo test -p codex-core` *(fails: suite::client::azure_overrides_assign_properties_used_for_responses_url, suite::client::env_var_overrides_loaded_auth, suite::tool_harness::apply_patch_tool_executes_and_emits_patch_events, suite::tools::shell_sandbox_denied_truncates_error_output require environment setup)*


------
https://chatgpt.com/codex/tasks/task_e_68e2ec4584408329825efec188006f98