### PR TITLE
Improve update_plan argument validation

### DIFF
--- a/codex-rs/core/src/tools/handlers/plan.rs
+++ b/codex-rs/core/src/tools/handlers/plan.rs
@@ -113,7 +113,69 @@ pub(crate) async fn handle_update_plan(
 }
 
 fn parse_update_plan_arguments(arguments: &str) -> Result<UpdatePlanArgs, FunctionCallError> {
-    serde_json::from_str::<UpdatePlanArgs>(arguments).map_err(|e| {
-        FunctionCallError::RespondToModel(format!("failed to parse function arguments: {e}"))
-    })
+    let payload = serde_json::from_str::<serde_json::Value>(arguments).map_err(|e| {
+        FunctionCallError::RespondToModel(format!(
+            "failed to parse function arguments as JSON object: {e}"
+        ))
+    })?;
+
+    let payload_obj = payload.as_object().ok_or_else(|| {
+        FunctionCallError::RespondToModel(
+            "invalid plan payload: expected a JSON object with a `plan` array".to_string(),
+        )
+    })?;
+
+    let plan_value = payload_obj.get("plan").ok_or_else(|| {
+        FunctionCallError::RespondToModel("invalid plan payload: missing `plan` array".to_string())
+    })?;
+
+    let plan_items = plan_value.as_array().ok_or_else(|| {
+        FunctionCallError::RespondToModel(
+            "invalid plan payload: `plan` must be an array of objects like {\"step\": \"...\", \"status\": \"pending\"}".
+                to_string(),
+        )
+    })?;
+
+    for (idx, item) in plan_items.iter().enumerate() {
+        let Some(item_obj) = item.as_object() else {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "invalid plan payload: item {idx} in `plan` is not an object"
+            )));
+        };
+
+        if !item_obj.contains_key("step") {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "invalid plan payload: item {idx} in `plan` is missing the `step` field"
+            )));
+        }
+
+        if !item_obj
+            .get("step")
+            .map(serde_json::Value::is_string)
+            .unwrap_or(false)
+        {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "invalid plan payload: `step` in item {idx} must be a string"
+            )));
+        }
+
+        if !item_obj.contains_key("status") {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "invalid plan payload: item {idx} in `plan` is missing the `status` field"
+            )));
+        }
+
+        if !item_obj
+            .get("status")
+            .map(serde_json::Value::is_string)
+            .unwrap_or(false)
+        {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "invalid plan payload: `status` in item {idx} must be a string"
+            )));
+        }
+    }
+
+    serde_json::from_value::<UpdatePlanArgs>(payload)
+        .map_err(|e| FunctionCallError::RespondToModel(format!("invalid plan payload: {e}")))
 }

--- a/codex-rs/core/tests/suite/tool_harness.rs
+++ b/codex-rs/core/tests/suite/tool_harness.rs
@@ -312,7 +312,7 @@ async fn update_plan_tool_rejects_malformed_payload() -> anyhow::Result<()> {
     );
     let output_text = extract_output_text(output_item).expect("output text present");
     assert!(
-        output_text.contains("failed to parse function arguments"),
+        output_text.contains("invalid plan payload"),
         "expected parse error message in output text, got {output_text:?}"
     );
     if let Some(success_flag) = output_item


### PR DESCRIPTION
## Summary
- validate update_plan tool payloads and surface actionable error messages
- update the tool harness test to expect the new validation response text

## Testing
- cargo test -p codex-core update_plan_tool

------
https://chatgpt.com/codex/tasks/task_e_68e367c6d87083299800eee482c6565f